### PR TITLE
Implement team creation restrictions and dashboard update

### DIFF
--- a/gui/CreaTeamGUI.java
+++ b/gui/CreaTeamGUI.java
@@ -46,7 +46,11 @@ public class CreaTeamGUI extends JFrame {
             JOptionPane.showMessageDialog(this, "Inserisci un nome per il team.", "Errore di input", JOptionPane.ERROR_MESSAGE);
             return;
         }
-        controller.creaTeam(nome);
+        Team t = controller.creaTeam(nome);
+        if (t == null) {
+            JOptionPane.showMessageDialog(this, "Impossibile creare il team.", "Errore", JOptionPane.ERROR_MESSAGE);
+            return;
+        }
         JOptionPane.showMessageDialog(this, "Team creato con successo.", "Successo", JOptionPane.INFORMATION_MESSAGE);
         dispose();
     }

--- a/gui/Dashboard.java
+++ b/gui/Dashboard.java
@@ -36,6 +36,9 @@ public class Dashboard extends JFrame {
         JTabbedPane tabs = new JTabbedPane();
         tabs.addTab("Overview", createOverviewPanel());
         tabs.addTab("Statistiche", createStatsPanel());
+        if (utente instanceof Partecipante && controller.hasTeam((Partecipante) utente)) {
+            tabs.addTab("Team", createTeamPanel());
+        }
         tabs.addTab("Link", createLinksPanel());
 
         getContentPane().add(tabs);
@@ -89,6 +92,42 @@ public class Dashboard extends JFrame {
             panel.add(new JLabel("Team da valutare: " + cntTeamsEval));
             panel.add(new JLabel("Giudice attivo"));
         }
+        return panel;
+    }
+
+    private JPanel createTeamPanel() {
+        JPanel panel = new JPanel(new BorderLayout(10, 10));
+        panel.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+
+        Partecipante p = (Partecipante) utente;
+        Team team = controller.getTeams(p).get(0);
+        JLabel info = new JLabel("Team: " + team.getNome() + " (" + team.getPartecipanti().size() + " membri)");
+        panel.add(info, BorderLayout.NORTH);
+
+        JPanel invitePanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        JTextField emailField = new JTextField(15);
+        JButton inviteBtn = StyleUtil.createButton("Invita", null);
+        inviteBtn.setEnabled(team.getPartecipanti().size() < controller.getMaxTeamSize());
+        inviteBtn.addActionListener(e -> {
+            String email = emailField.getText().trim();
+            if (email.isEmpty()) {
+                JOptionPane.showMessageDialog(this, "Inserisci email", "Errore", JOptionPane.ERROR_MESSAGE);
+                return;
+            }
+            if (controller.aggiungiMembroTeam(team, email)) {
+                JOptionPane.showMessageDialog(this, "Partecipante aggiunto", "Successo", JOptionPane.INFORMATION_MESSAGE);
+                emailField.setText("");
+                info.setText("Team: " + team.getNome() + " (" + team.getPartecipanti().size() + " membri)");
+                inviteBtn.setEnabled(team.getPartecipanti().size() < controller.getMaxTeamSize());
+            } else {
+                JOptionPane.showMessageDialog(this, "Impossibile aggiungere partecipante", "Errore", JOptionPane.ERROR_MESSAGE);
+            }
+        });
+        invitePanel.add(new JLabel("Email:"));
+        invitePanel.add(emailField);
+        invitePanel.add(inviteBtn);
+        panel.add(invitePanel, BorderLayout.SOUTH);
+
         return panel;
     }
 

--- a/gui/MainMenuGUI.java
+++ b/gui/MainMenuGUI.java
@@ -53,6 +53,9 @@ public class MainMenuGUI extends JFrame {
             creaTeam.setAlignmentX(Component.CENTER_ALIGNMENT);
             creaTeam.setMaximumSize(new Dimension(Integer.MAX_VALUE, 50));
             creaTeam.addActionListener(e -> new CreaTeamGUI(controller));
+            if (controller.hasTeam((Partecipante) u)) {
+                creaTeam.setEnabled(false);
+            }
             btnPanel.add(creaTeam);
             btnPanel.add(Box.createVerticalStrut(10));
 


### PR DESCRIPTION
## Summary
- limit team creation to one per participant and avoid duplicate team names
- disable "Crea Team" button when a user already has a team
- show a new Team tab in the dashboard where members can invite others
- handle team creation errors in the GUI

## Testing
- `javac @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_6862b569f6848329baf9e0d818870a57