### PR TITLE
Implement file-based state repository

### DIFF
--- a/controller/ControllerState.java
+++ b/controller/ControllerState.java
@@ -1,0 +1,40 @@
+package controller;
+
+import model.*;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ControllerState implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private List<Utente> utenti;
+    private List<Documento> docs;
+    private List<Voto> voti;
+    private List<Invito> inviti;
+    private List<Team> teams;
+    private List<Hackathon> hacks;
+
+    public ControllerState() {
+        this.utenti = new ArrayList<>();
+        this.docs = new ArrayList<>();
+        this.voti = new ArrayList<>();
+        this.inviti = new ArrayList<>();
+        this.teams = new ArrayList<>();
+        this.hacks = new ArrayList<>();
+    }
+
+    public List<Utente> getUtenti() { return utenti; }
+    public void setUtenti(List<Utente> utenti) { this.utenti = utenti; }
+    public List<Documento> getDocs() { return docs; }
+    public void setDocs(List<Documento> docs) { this.docs = docs; }
+    public List<Voto> getVoti() { return voti; }
+    public void setVoti(List<Voto> voti) { this.voti = voti; }
+    public List<Invito> getInviti() { return inviti; }
+    public void setInviti(List<Invito> inviti) { this.inviti = inviti; }
+    public List<Team> getTeams() { return teams; }
+    public void setTeams(List<Team> teams) { this.teams = teams; }
+    public List<Hackathon> getHacks() { return hacks; }
+    public void setHacks(List<Hackathon> hacks) { this.hacks = hacks; }
+}

--- a/controller/FileStateRepository.java
+++ b/controller/FileStateRepository.java
@@ -1,0 +1,34 @@
+package controller;
+
+import java.io.*;
+
+public class FileStateRepository implements StateRepository {
+    private static final String DATA_DIR = "data";
+    private static final String STATE_FILE = DATA_DIR + "/state.dat";
+
+    @Override
+    public ControllerState load() {
+        File file = new File(STATE_FILE);
+        if (!file.exists()) {
+            return new ControllerState();
+        }
+        try (ObjectInputStream in = new ObjectInputStream(new FileInputStream(file))) {
+            return (ControllerState) in.readObject();
+        } catch (IOException | ClassNotFoundException e) {
+            return new ControllerState();
+        }
+    }
+
+    @Override
+    public void save(ControllerState state) {
+        File dir = new File(DATA_DIR);
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+        try (ObjectOutputStream out = new ObjectOutputStream(new FileOutputStream(STATE_FILE))) {
+            out.writeObject(state);
+        } catch (IOException e) {
+            // handle exception silently
+        }
+    }
+}

--- a/controller/StateRepository.java
+++ b/controller/StateRepository.java
@@ -1,0 +1,6 @@
+package controller;
+
+public interface StateRepository {
+    ControllerState load();
+    void save(ControllerState state);
+}


### PR DESCRIPTION
## Summary
- Define `StateRepository` interface for persisting `ControllerState`.
- Create serializable `ControllerState` holding user, document, vote, invitation, team and hackathon lists.
- Implement `FileStateRepository` to load and save state in `data/state.dat` with object streams.

## Testing
- `javac -d /tmp/out @sources.txt`


------
https://chatgpt.com/codex/tasks/task_e_6891203c59b083299ffbfa258e3a0eac