### PR TITLE
Rimuovi riferimenti alla persistenza su file

### DIFF
--- a/controller/Controller.java
+++ b/controller/Controller.java
@@ -9,7 +9,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * Controller centralizza la logica applicativa e persistenza in file.
+ * Controller centralizza la logica applicativa.
  */
 public class Controller {
     private static final int MAX_TEAM_SIZE = 4;

--- a/model/Documento.java
+++ b/model/Documento.java
@@ -4,13 +4,11 @@ package model;
 
 import java.time.LocalDate;
 import java.io.File;
-import java.io.Serializable;
 
 /**
  * Rappresenta un documento caricato per un hackathon.
  */
-public class Documento implements Serializable {
-    private static final long serialVersionUID = 1L;
+public class Documento {
     private LocalDate data;
     private String contenuto;
     private File file;

--- a/model/Hackathon.java
+++ b/model/Hackathon.java
@@ -4,10 +4,8 @@ package model;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
-import java.io.Serializable;
 
-public class Hackathon implements Serializable {
-    private static final long serialVersionUID = 1L;
+public class Hackathon {
     private String titolo;
     private String sede;
     private LocalDateTime dataInizio;

--- a/model/Invito.java
+++ b/model/Invito.java
@@ -3,13 +3,11 @@
 package model;
 
 import java.time.LocalDate;
-import java.io.Serializable;
 
 /**
  * Invito ad un hackathon per un partecipante.
  */
-public class Invito implements Serializable {
-    private static final long serialVersionUID = 1L;
+public class Invito {
     public enum Stato { INVIATO, ACCETTATO, RIFIUTATO }
 
     private final Hackathon hackathon;

--- a/model/Team.java
+++ b/model/Team.java
@@ -5,10 +5,8 @@ package model;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.io.Serializable;
 
-public class Team implements Serializable {
-    private static final long serialVersionUID = 1L;
+public class Team {
     private String nome;
     private final List<Partecipante> partecipanti = new ArrayList<>();
     private int voto = -1;

--- a/model/Utente.java
+++ b/model/Utente.java
@@ -1,15 +1,13 @@
 // File: Utente.java
 package model;
 
-import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.Objects;
 
 /**
  * Rappresenta un utente generico del sistema.
  */
-public class Utente implements Serializable {
-    private static final long serialVersionUID = 1L;
+public class Utente {
 
     protected String nome;
     protected String cognome;

--- a/model/Voto.java
+++ b/model/Voto.java
@@ -3,13 +3,11 @@
 package model;
 
 import java.util.Objects;
-import java.io.Serializable;
 
 /**
  * Rappresenta un voto assegnato a un team.
  */
-public class Voto implements Serializable {
-    private static final long serialVersionUID = 1L;
+public class Voto {
     private final Team team;
     private final int punteggio;
 


### PR DESCRIPTION
## Summary
- Rimosse le tracce di persistenza dal controller e dai modelli, eliminando i riferimenti alla serializzazione.
- Confermato che il `Main` istanzia direttamente il controller senza salvataggi o caricamenti da file.

## Testing
- `javac -d out_tmp $(find controller model gui -name "*.java")`


------
https://chatgpt.com/codex/tasks/task_e_68912bc9fbc4832992133d7e40d09104