### PR TITLE
Expand registration and final voting diagrams

### DIFF
--- a/docs/sequence/finalVoting.puml
+++ b/docs/sequence/finalVoting.puml
@@ -1,8 +1,17 @@
 @startuml
-participant Judge
+participant Judge1
+participant Judge2
 participant Controller
 participant VoteDAO
-Judge -> Controller: castVote
-Controller -> VoteDAO: save
+
+Judge1 -> Controller: castVote
+Controller -> VoteDAO: saveVote
+Judge2 -> Controller: castVote
+Controller -> VoteDAO: saveVote
+
+Controller -> VoteDAO: loadAllVotes
+VoteDAO --> Controller: votes
 Controller -> Controller: computeRanking
+Controller -> Judge1: showRanking
+Controller -> Judge2: showRanking
 @enduml

--- a/docs/sequence/registration.puml
+++ b/docs/sequence/registration.puml
@@ -1,5 +1,18 @@
 @startuml
 actor Utente
-Utente -> Controller: registerUser
-Controller -> HackathonDAO: save
+participant Controller
+participant HackathonDAO
+
+Utente -> Controller: openRegistrationForm
+Utente -> Controller: submitRegistration
+Controller -> Controller: validateData
+Controller -> HackathonDAO: isRegistrationOpen
+HackathonDAO --> Controller: deadlineStatus
+alt registration open
+    Controller -> HackathonDAO: saveParticipant
+    HackathonDAO --> Controller: saved
+    Controller -> Utente: confirmRegistration
+else registration closed
+    Controller -> Utente: rejectRegistration
+end
 @enduml


### PR DESCRIPTION
## Summary
- Expand registration sequence diagram with user actions, controller logic, DAO interactions, and deadline handling.
- Illustrate multi-judge final voting with vote persistence and ranking computation.

## Testing
- `mvn -q test` *(fails: Network is unreachable for Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_6891507063f48329bf3fed0bf713bf4e