### PR TITLE
Add PostgreSQL DAO implementations with CRUD operations

### DIFF
--- a/src/main/java/dao/HackathonDAO.java
+++ b/src/main/java/dao/HackathonDAO.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface HackathonDAO {
     void save(Hackathon hackathon);
     Optional<Hackathon> findById(int id);
+    void update(Hackathon hackathon);
+    void delete(int id);
 }

--- a/src/main/java/dao/ProgressDAO.java
+++ b/src/main/java/dao/ProgressDAO.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface ProgressDAO {
     void save(Progress progress);
     Optional<Progress> findById(int id);
+    void update(Progress progress);
+    void delete(int id);
 }

--- a/src/main/java/dao/TeamDAO.java
+++ b/src/main/java/dao/TeamDAO.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface TeamDAO {
     void save(Team team);
     Optional<Team> findById(int id);
+    void update(Team team);
+    void delete(int id);
 }

--- a/src/main/java/dao/UtenteDAO.java
+++ b/src/main/java/dao/UtenteDAO.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface UtenteDAO {
     void save(Utente utente);
     Optional<Utente> findById(int id);
+    void update(Utente utente);
+    void delete(int id);
 }

--- a/src/main/java/dao/VoteDAO.java
+++ b/src/main/java/dao/VoteDAO.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface VoteDAO {
     void save(Vote vote);
     Optional<Vote> findById(int id);
+    void update(Vote vote);
+    void delete(int id);
 }

--- a/src/main/java/implementazionePostgresDAO/PostgresHackathonDAO.java
+++ b/src/main/java/implementazionePostgresDAO/PostgresHackathonDAO.java
@@ -1,0 +1,97 @@
+package implementazionePostgresDAO;
+
+import dao.HackathonDAO;
+import database.DatabaseConfig;
+import model.Hackathon;
+import model.Utente;
+
+import java.sql.*;
+import java.util.Optional;
+
+/** Implementazione PostgreSQL di {@link HackathonDAO}. */
+public class PostgresHackathonDAO implements HackathonDAO {
+    @Override
+    public void save(Hackathon hackathon) {
+        String sql = "INSERT INTO hackathon(id, titolo, inizio, fine, chiusura_iscrizioni, max_partecipanti, max_team, organizzatore_id) VALUES(?,?,?,?,?,?,?,?)";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, hackathon.getId());
+            ps.setString(2, hackathon.getTitolo());
+            ps.setDate(3, Date.valueOf(hackathon.getInizio()));
+            ps.setDate(4, Date.valueOf(hackathon.getFine()));
+            ps.setDate(5, Date.valueOf(hackathon.getChiusuraIscrizioni()));
+            ps.setInt(6, hackathon.getMaxPartecipanti());
+            ps.setInt(7, hackathon.getMaxTeam());
+            ps.setInt(8, hackathon.getOrganizzatore().getId());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Optional<Hackathon> findById(int id) {
+        String sql = "SELECT h.id, h.titolo, h.inizio, h.fine, h.chiusura_iscrizioni, h.max_partecipanti, h.max_team, " +
+                "u.id AS oid, u.nome AS onome, u.email AS oemail, u.ruolo AS oruolo " +
+                "FROM hackathon h JOIN utenti u ON h.organizzatore_id = u.id WHERE h.id = ?";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    Utente org = new Utente(
+                            rs.getInt("oid"),
+                            rs.getString("onome"),
+                            rs.getString("oemail"),
+                            Utente.Ruolo.valueOf(rs.getString("oruolo"))
+                    );
+                    Hackathon h = new Hackathon(
+                            rs.getInt("id"),
+                            rs.getString("titolo"),
+                            rs.getDate("inizio").toLocalDate(),
+                            rs.getDate("fine").toLocalDate(),
+                            rs.getDate("chiusura_iscrizioni").toLocalDate(),
+                            rs.getInt("max_partecipanti"),
+                            rs.getInt("max_team"),
+                            org
+                    );
+                    return Optional.of(h);
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public void update(Hackathon hackathon) {
+        String sql = "UPDATE hackathon SET titolo=?, inizio=?, fine=?, chiusura_iscrizioni=?, max_partecipanti=?, max_team=?, organizzatore_id=? WHERE id=?";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setString(1, hackathon.getTitolo());
+            ps.setDate(2, Date.valueOf(hackathon.getInizio()));
+            ps.setDate(3, Date.valueOf(hackathon.getFine()));
+            ps.setDate(4, Date.valueOf(hackathon.getChiusuraIscrizioni()));
+            ps.setInt(5, hackathon.getMaxPartecipanti());
+            ps.setInt(6, hackathon.getMaxTeam());
+            ps.setInt(7, hackathon.getOrganizzatore().getId());
+            ps.setInt(8, hackathon.getId());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void delete(int id) {
+        String sql = "DELETE FROM hackathon WHERE id = ?";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/implementazionePostgresDAO/PostgresProgressDAO.java
+++ b/src/main/java/implementazionePostgresDAO/PostgresProgressDAO.java
@@ -1,0 +1,92 @@
+package implementazionePostgresDAO;
+
+import dao.ProgressDAO;
+import database.DatabaseConfig;
+import model.Progress;
+import model.Team;
+import model.Utente;
+
+import java.sql.*;
+import java.util.Optional;
+
+/** Implementazione PostgreSQL di {@link ProgressDAO}. */
+public class PostgresProgressDAO implements ProgressDAO {
+    @Override
+    public void save(Progress progress) {
+        String sql = "INSERT INTO progressi(id, team_id, descrizione, timestamp) VALUES(?,?,?,?)";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, progress.getId());
+            ps.setInt(2, progress.getTeam().getId());
+            ps.setString(3, progress.getDescrizione());
+            ps.setTimestamp(4, Timestamp.valueOf(progress.getTimestamp()));
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Optional<Progress> findById(int id) {
+        String sql = "SELECT p.id, p.descrizione, p.timestamp, t.id AS tid, t.nome AS tnome, t.max_size, t.creatore_id, " +
+                "u.id AS uid, u.nome AS unome, u.email AS uemail, u.ruolo AS uruolo " +
+                "FROM progressi p JOIN teams t ON p.team_id = t.id JOIN utenti u ON t.creatore_id = u.id WHERE p.id = ?";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    Utente creatore = new Utente(
+                            rs.getInt("uid"),
+                            rs.getString("unome"),
+                            rs.getString("uemail"),
+                            Utente.Ruolo.valueOf(rs.getString("uruolo"))
+                    );
+                    Team team = new Team(
+                            rs.getInt("tid"),
+                            rs.getString("tnome"),
+                            rs.getInt("max_size"),
+                            creatore
+                    );
+                    Progress progress = new Progress(
+                            rs.getInt("id"),
+                            team,
+                            rs.getString("descrizione"),
+                            rs.getTimestamp("timestamp").toLocalDateTime()
+                    );
+                    return Optional.of(progress);
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public void update(Progress progress) {
+        String sql = "UPDATE progressi SET team_id=?, descrizione=?, timestamp=? WHERE id=?";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, progress.getTeam().getId());
+            ps.setString(2, progress.getDescrizione());
+            ps.setTimestamp(3, Timestamp.valueOf(progress.getTimestamp()));
+            ps.setInt(4, progress.getId());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void delete(int id) {
+        String sql = "DELETE FROM progressi WHERE id = ?";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/implementazionePostgresDAO/PostgresTeamDAO.java
+++ b/src/main/java/implementazionePostgresDAO/PostgresTeamDAO.java
@@ -1,0 +1,84 @@
+package implementazionePostgresDAO;
+
+import dao.TeamDAO;
+import database.DatabaseConfig;
+import model.Team;
+import model.Utente;
+
+import java.sql.*;
+import java.util.Optional;
+
+/** Implementazione PostgreSQL di {@link TeamDAO}. */
+public class PostgresTeamDAO implements TeamDAO {
+    @Override
+    public void save(Team team) {
+        String sql = "INSERT INTO teams(id, nome, max_size, creatore_id) VALUES(?,?,?,?)";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, team.getId());
+            ps.setString(2, team.getNome());
+            ps.setInt(3, team.getMaxSize());
+            ps.setInt(4, team.getMembri().get(0).getId());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Optional<Team> findById(int id) {
+        String sql = "SELECT t.id, t.nome, t.max_size, u.id AS uid, u.nome AS unome, u.email AS uemail, u.ruolo AS uruolo " +
+                "FROM teams t JOIN utenti u ON t.creatore_id = u.id WHERE t.id = ?";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    Utente creatore = new Utente(
+                            rs.getInt("uid"),
+                            rs.getString("unome"),
+                            rs.getString("uemail"),
+                            Utente.Ruolo.valueOf(rs.getString("uruolo"))
+                    );
+                    Team team = new Team(
+                            rs.getInt("id"),
+                            rs.getString("nome"),
+                            rs.getInt("max_size"),
+                            creatore
+                    );
+                    return Optional.of(team);
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public void update(Team team) {
+        String sql = "UPDATE teams SET nome=?, max_size=?, creatore_id=? WHERE id=?";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setString(1, team.getNome());
+            ps.setInt(2, team.getMaxSize());
+            ps.setInt(3, team.getMembri().get(0).getId());
+            ps.setInt(4, team.getId());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void delete(int id) {
+        String sql = "DELETE FROM teams WHERE id = ?";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/implementazionePostgresDAO/PostgresUtenteDAO.java
+++ b/src/main/java/implementazionePostgresDAO/PostgresUtenteDAO.java
@@ -48,4 +48,31 @@ public class PostgresUtenteDAO implements UtenteDAO {
         }
         return Optional.empty();
     }
+
+    @Override
+    public void update(Utente utente) {
+        String sql = "UPDATE utenti SET nome=?, email=?, ruolo=? WHERE id=?";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setString(1, utente.getNome());
+            ps.setString(2, utente.getEmail());
+            ps.setString(3, utente.getRuolo().name());
+            ps.setInt(4, utente.getId());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void delete(int id) {
+        String sql = "DELETE FROM utenti WHERE id=?";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/src/main/java/implementazionePostgresDAO/PostgresVoteDAO.java
+++ b/src/main/java/implementazionePostgresDAO/PostgresVoteDAO.java
@@ -1,0 +1,101 @@
+package implementazionePostgresDAO;
+
+import dao.VoteDAO;
+import database.DatabaseConfig;
+import model.Team;
+import model.Utente;
+import model.Vote;
+
+import java.sql.*;
+import java.util.Optional;
+
+/** Implementazione PostgreSQL di {@link VoteDAO}. */
+public class PostgresVoteDAO implements VoteDAO {
+    @Override
+    public void save(Vote vote) {
+        String sql = "INSERT INTO voti(id, team_id, giudice_id, valore) VALUES(?,?,?,?)";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, vote.getId());
+            ps.setInt(2, vote.getTeam().getId());
+            ps.setInt(3, vote.getGiudice().getId());
+            ps.setInt(4, vote.getValore());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Optional<Vote> findById(int id) {
+        String sql = "SELECT v.id, v.valore, t.id AS tid, t.nome AS tnome, t.max_size, t.creatore_id, " +
+                "uc.id AS cuid, uc.nome AS cunome, uc.email AS cuemail, uc.ruolo AS curuolo, " +
+                "ug.id AS jid, ug.nome AS jnome, ug.email AS jemail, ug.ruolo AS jruolo " +
+                "FROM voti v JOIN teams t ON v.team_id = t.id " +
+                "JOIN utenti uc ON t.creatore_id = uc.id " +
+                "JOIN utenti ug ON v.giudice_id = ug.id WHERE v.id = ?";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    Utente creatore = new Utente(
+                            rs.getInt("cuid"),
+                            rs.getString("cunome"),
+                            rs.getString("cuemail"),
+                            Utente.Ruolo.valueOf(rs.getString("curuolo"))
+                    );
+                    Team team = new Team(
+                            rs.getInt("tid"),
+                            rs.getString("tnome"),
+                            rs.getInt("max_size"),
+                            creatore
+                    );
+                    Utente giudice = new Utente(
+                            rs.getInt("jid"),
+                            rs.getString("jnome"),
+                            rs.getString("jemail"),
+                            Utente.Ruolo.valueOf(rs.getString("jruolo"))
+                    );
+                    Vote vote = new Vote(
+                            rs.getInt("id"),
+                            team,
+                            giudice,
+                            rs.getInt("valore")
+                    );
+                    return Optional.of(vote);
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public void update(Vote vote) {
+        String sql = "UPDATE voti SET team_id=?, giudice_id=?, valore=? WHERE id=?";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, vote.getTeam().getId());
+            ps.setInt(2, vote.getGiudice().getId());
+            ps.setInt(3, vote.getValore());
+            ps.setInt(4, vote.getId());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void delete(int id) {
+        String sql = "DELETE FROM voti WHERE id = ?";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/dao/PostgresHackathonDAOTest.java
+++ b/src/test/java/dao/PostgresHackathonDAOTest.java
@@ -1,0 +1,47 @@
+package dao;
+
+import implementazionePostgresDAO.PostgresHackathonDAO;
+import model.Hackathon;
+import model.Utente;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Test di integrazione per {@link PostgresHackathonDAO}. */
+public class PostgresHackathonDAOTest {
+    private PostgresHackathonDAO dao;
+    private Utente organizzatore;
+
+    @BeforeEach
+    void setup() throws Exception {
+        System.setProperty("db.url", "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1");
+        System.setProperty("db.user", "sa");
+        System.setProperty("db.password", "");
+        dao = new PostgresHackathonDAO();
+        organizzatore = new Utente(1, "Org", "org@example.com", Utente.Ruolo.ORGANIZER);
+        try (Connection c = database.DatabaseConfig.getConnection();
+             Statement st = c.createStatement()) {
+            st.executeUpdate("CREATE TABLE utenti(id INT PRIMARY KEY, nome VARCHAR(100), email VARCHAR(100), ruolo VARCHAR(20))");
+            st.executeUpdate("CREATE TABLE hackathon(id INT PRIMARY KEY, titolo VARCHAR(100), inizio DATE, fine DATE, chiusura_iscrizioni DATE, max_partecipanti INT, max_team INT, organizzatore_id INT)");
+            st.executeUpdate("INSERT INTO utenti(id, nome, email, ruolo) VALUES(1, 'Org', 'org@example.com', 'ORGANIZER')");
+        }
+    }
+
+    @Test
+    void crud() {
+        Hackathon h = new Hackathon(1, "Hack1", LocalDate.now(), LocalDate.now().plusDays(1), LocalDate.now().plusDays(2), 100, 10, organizzatore);
+        dao.save(h);
+        Hackathon found = dao.findById(1).orElseThrow();
+        assertEquals("Hack1", found.getTitolo());
+        Hackathon h2 = new Hackathon(1, "Hack2", h.getInizio(), h.getFine(), h.getChiusuraIscrizioni(), h.getMaxPartecipanti(), h.getMaxTeam(), organizzatore);
+        dao.update(h2);
+        assertEquals("Hack2", dao.findById(1).orElseThrow().getTitolo());
+        dao.delete(1);
+        assertTrue(dao.findById(1).isEmpty());
+    }
+}

--- a/src/test/java/dao/PostgresProgressDAOTest.java
+++ b/src/test/java/dao/PostgresProgressDAOTest.java
@@ -1,0 +1,51 @@
+package dao;
+
+import implementazionePostgresDAO.PostgresProgressDAO;
+import model.Progress;
+import model.Team;
+import model.Utente;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Test di integrazione per {@link PostgresProgressDAO}. */
+public class PostgresProgressDAOTest {
+    private PostgresProgressDAO dao;
+    private Team team;
+
+    @BeforeEach
+    void setup() throws Exception {
+        System.setProperty("db.url", "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1");
+        System.setProperty("db.user", "sa");
+        System.setProperty("db.password", "");
+        dao = new PostgresProgressDAO();
+        Utente creatore = new Utente(1, "Mario", "mario@example.com", Utente.Ruolo.PARTICIPANT);
+        team = new Team(1, "Team1", 5, creatore);
+        try (Connection c = database.DatabaseConfig.getConnection();
+             Statement st = c.createStatement()) {
+            st.executeUpdate("CREATE TABLE utenti(id INT PRIMARY KEY, nome VARCHAR(100), email VARCHAR(100), ruolo VARCHAR(20))");
+            st.executeUpdate("CREATE TABLE teams(id INT PRIMARY KEY, nome VARCHAR(100), max_size INT, creatore_id INT)");
+            st.executeUpdate("CREATE TABLE progressi(id INT PRIMARY KEY, team_id INT, descrizione VARCHAR(255), timestamp TIMESTAMP)");
+            st.executeUpdate("INSERT INTO utenti(id, nome, email, ruolo) VALUES(1, 'Mario', 'mario@example.com', 'PARTICIPANT')");
+            st.executeUpdate("INSERT INTO teams(id, nome, max_size, creatore_id) VALUES(1, 'Team1', 5, 1)");
+        }
+    }
+
+    @Test
+    void crud() {
+        Progress p = new Progress(1, team, "desc", LocalDateTime.now());
+        dao.save(p);
+        Progress found = dao.findById(1).orElseThrow();
+        assertEquals("desc", found.getDescrizione());
+        Progress upd = new Progress(1, team, "nuova", LocalDateTime.now().plusHours(1));
+        dao.update(upd);
+        assertEquals("nuova", dao.findById(1).orElseThrow().getDescrizione());
+        dao.delete(1);
+        assertTrue(dao.findById(1).isEmpty());
+    }
+}

--- a/src/test/java/dao/PostgresTeamDAOTest.java
+++ b/src/test/java/dao/PostgresTeamDAOTest.java
@@ -1,0 +1,46 @@
+package dao;
+
+import implementazionePostgresDAO.PostgresTeamDAO;
+import model.Team;
+import model.Utente;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Test di integrazione per {@link PostgresTeamDAO}. */
+public class PostgresTeamDAOTest {
+    private PostgresTeamDAO dao;
+    private Utente creatore;
+
+    @BeforeEach
+    void setup() throws Exception {
+        System.setProperty("db.url", "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1");
+        System.setProperty("db.user", "sa");
+        System.setProperty("db.password", "");
+        dao = new PostgresTeamDAO();
+        creatore = new Utente(1, "Mario", "mario@example.com", Utente.Ruolo.PARTICIPANT);
+        try (Connection c = database.DatabaseConfig.getConnection();
+             Statement st = c.createStatement()) {
+            st.executeUpdate("CREATE TABLE utenti(id INT PRIMARY KEY, nome VARCHAR(100), email VARCHAR(100), ruolo VARCHAR(20))");
+            st.executeUpdate("CREATE TABLE teams(id INT PRIMARY KEY, nome VARCHAR(100), max_size INT, creatore_id INT)");
+            st.executeUpdate("INSERT INTO utenti(id, nome, email, ruolo) VALUES(1, 'Mario', 'mario@example.com', 'PARTICIPANT')");
+        }
+    }
+
+    @Test
+    void crud() {
+        Team team = new Team(1, "Team1", 5, creatore);
+        dao.save(team);
+        Team found = dao.findById(1).orElseThrow();
+        assertEquals("Team1", found.getNome());
+        Team updated = new Team(1, "Team1", 6, creatore);
+        dao.update(updated);
+        assertEquals(6, dao.findById(1).orElseThrow().getMaxSize());
+        dao.delete(1);
+        assertTrue(dao.findById(1).isEmpty());
+    }
+}

--- a/src/test/java/dao/PostgresVoteDAOTest.java
+++ b/src/test/java/dao/PostgresVoteDAOTest.java
@@ -1,0 +1,53 @@
+package dao;
+
+import implementazionePostgresDAO.PostgresVoteDAO;
+import model.Team;
+import model.Utente;
+import model.Vote;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Test di integrazione per {@link PostgresVoteDAO}. */
+public class PostgresVoteDAOTest {
+    private PostgresVoteDAO dao;
+    private Team team;
+    private Utente giudice;
+
+    @BeforeEach
+    void setup() throws Exception {
+        System.setProperty("db.url", "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1");
+        System.setProperty("db.user", "sa");
+        System.setProperty("db.password", "");
+        dao = new PostgresVoteDAO();
+        Utente creatore = new Utente(1, "Mario", "mario@example.com", Utente.Ruolo.PARTICIPANT);
+        giudice = new Utente(2, "Giulia", "giulia@example.com", Utente.Ruolo.JUDGE);
+        team = new Team(1, "Team1", 5, creatore);
+        try (Connection c = database.DatabaseConfig.getConnection();
+             Statement st = c.createStatement()) {
+            st.executeUpdate("CREATE TABLE utenti(id INT PRIMARY KEY, nome VARCHAR(100), email VARCHAR(100), ruolo VARCHAR(20))");
+            st.executeUpdate("CREATE TABLE teams(id INT PRIMARY KEY, nome VARCHAR(100), max_size INT, creatore_id INT)");
+            st.executeUpdate("CREATE TABLE voti(id INT PRIMARY KEY, team_id INT, giudice_id INT, valore INT)");
+            st.executeUpdate("INSERT INTO utenti(id, nome, email, ruolo) VALUES(1, 'Mario', 'mario@example.com', 'PARTICIPANT')");
+            st.executeUpdate("INSERT INTO utenti(id, nome, email, ruolo) VALUES(2, 'Giulia', 'giulia@example.com', 'JUDGE')");
+            st.executeUpdate("INSERT INTO teams(id, nome, max_size, creatore_id) VALUES(1, 'Team1', 5, 1)");
+        }
+    }
+
+    @Test
+    void crud() {
+        Vote v = new Vote(1, team, giudice, 7);
+        dao.save(v);
+        Vote found = dao.findById(1).orElseThrow();
+        assertEquals(7, found.getValore());
+        Vote upd = new Vote(1, team, giudice, 8);
+        dao.update(upd);
+        assertEquals(8, dao.findById(1).orElseThrow().getValore());
+        dao.delete(1);
+        assertTrue(dao.findById(1).isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- extend DAO interfaces with update and delete methods
- implement PostgreSQL Hackathon, Team, Progress and Vote DAOs using `DatabaseConfig`
- add integration tests for new DAOs with H2

## Testing
- `mvn -q -DskipTests=false test` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891506be858832987a4b17f25ca6eed