### PR TITLE
feat(gui): add swing panels for hackathon management

### DIFF
--- a/src/main/java/gui/HackathonPanel.java
+++ b/src/main/java/gui/HackathonPanel.java
@@ -1,0 +1,77 @@
+package gui;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionListener;
+
+/**
+ * Panel managing hackathon lifecycle and registrations.
+ */
+public class HackathonPanel extends JPanel {
+    private final JTextField idField = new JTextField(5);
+    private final JTextField titleField = new JTextField(20);
+    private final JTextField startField = new JTextField(10);
+    private final JTextField endField = new JTextField(10);
+    private final JTextField deadlineField = new JTextField(10);
+    private final JTextField maxParticipantsField = new JTextField(5);
+    private final JTextField maxTeamField = new JTextField(5);
+
+    private final JButton createButton = new JButton("Create");
+    private final JButton editButton = new JButton("Edit");
+    private final JButton deleteButton = new JButton("Delete");
+    private final JButton registerButton = new JButton("Register");
+
+    public HackathonPanel() {
+        setLayout(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(4,4,4,4);
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+
+        gbc.gridx = 0; gbc.gridy = 0; add(new JLabel("ID:"), gbc);
+        gbc.gridx = 1; add(idField, gbc);
+        gbc.gridx = 0; gbc.gridy = 1; add(new JLabel("Title:"), gbc);
+        gbc.gridx = 1; add(titleField, gbc);
+        gbc.gridx = 0; gbc.gridy = 2; add(new JLabel("Start date:"), gbc);
+        gbc.gridx = 1; add(startField, gbc);
+        gbc.gridx = 0; gbc.gridy = 3; add(new JLabel("End date:"), gbc);
+        gbc.gridx = 1; add(endField, gbc);
+        gbc.gridx = 0; gbc.gridy = 4; add(new JLabel("Reg. deadline:"), gbc);
+        gbc.gridx = 1; add(deadlineField, gbc);
+        gbc.gridx = 0; gbc.gridy = 5; add(new JLabel("Max participants:"), gbc);
+        gbc.gridx = 1; add(maxParticipantsField, gbc);
+        gbc.gridx = 0; gbc.gridy = 6; add(new JLabel("Max team size:"), gbc);
+        gbc.gridx = 1; add(maxTeamField, gbc);
+
+        gbc.gridx = 0; gbc.gridy = 7; gbc.gridwidth = 2;
+        JPanel buttons = new JPanel();
+        buttons.add(createButton);
+        buttons.add(editButton);
+        buttons.add(deleteButton);
+        buttons.add(registerButton);
+        add(buttons, gbc);
+    }
+
+    public void addCreateListener(ActionListener listener) {
+        createButton.addActionListener(listener);
+    }
+
+    public void addEditListener(ActionListener listener) {
+        editButton.addActionListener(listener);
+    }
+
+    public void addDeleteListener(ActionListener listener) {
+        deleteButton.addActionListener(listener);
+    }
+
+    public void addRegisterListener(ActionListener listener) {
+        registerButton.addActionListener(listener);
+    }
+
+    public JTextField getIdField() { return idField; }
+    public JTextField getTitleField() { return titleField; }
+    public JTextField getStartField() { return startField; }
+    public JTextField getEndField() { return endField; }
+    public JTextField getDeadlineField() { return deadlineField; }
+    public JTextField getMaxParticipantsField() { return maxParticipantsField; }
+    public JTextField getMaxTeamField() { return maxTeamField; }
+}

--- a/src/main/java/gui/LoginPanel.java
+++ b/src/main/java/gui/LoginPanel.java
@@ -1,0 +1,56 @@
+package gui;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionListener;
+
+/**
+ * Panel responsible for user login and registration actions.
+ */
+public class LoginPanel extends JPanel {
+    private final JTextField emailField = new JTextField(20);
+    private final JPasswordField passwordField = new JPasswordField(20);
+    private final JButton loginButton = new JButton("Login");
+    private final JButton registerButton = new JButton("Register");
+
+    public LoginPanel() {
+        setLayout(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(5, 5, 5, 5);
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+
+        gbc.gridx = 0; gbc.gridy = 0;
+        add(new JLabel("Email:"), gbc);
+        gbc.gridx = 1;
+        add(emailField, gbc);
+
+        gbc.gridx = 0; gbc.gridy = 1;
+        add(new JLabel("Password:"), gbc);
+        gbc.gridx = 1;
+        add(passwordField, gbc);
+
+        gbc.gridx = 0; gbc.gridy = 2; gbc.gridwidth = 2;
+        JPanel buttons = new JPanel();
+        buttons.add(loginButton);
+        buttons.add(registerButton);
+        add(buttons, gbc);
+    }
+
+    /** Registers a listener for the login action. */
+    public void addLoginListener(ActionListener listener) {
+        loginButton.addActionListener(listener);
+    }
+
+    /** Registers a listener for the registration action. */
+    public void addRegisterListener(ActionListener listener) {
+        registerButton.addActionListener(listener);
+    }
+
+    public JTextField getEmailField() {
+        return emailField;
+    }
+
+    public JPasswordField getPasswordField() {
+        return passwordField;
+    }
+}

--- a/src/main/java/gui/MainFrame.java
+++ b/src/main/java/gui/MainFrame.java
@@ -1,0 +1,45 @@
+package gui;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * Main application frame hosting all panels using a {@link CardLayout}.
+ */
+public class MainFrame extends JFrame {
+    private final CardLayout layout = new CardLayout();
+    private final JPanel container = new JPanel(layout);
+
+    private final LoginPanel loginPanel = new LoginPanel();
+    private final HackathonPanel hackathonPanel = new HackathonPanel();
+    private final TeamPanel teamPanel = new TeamPanel();
+    private final ProgressPanel progressPanel = new ProgressPanel();
+    private final VotePanel votePanel = new VotePanel();
+
+    public MainFrame() {
+        super("Hackathon Manager");
+        setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        setContentPane(container);
+
+        container.add(loginPanel, "login");
+        container.add(hackathonPanel, "hackathon");
+        container.add(teamPanel, "team");
+        container.add(progressPanel, "progress");
+        container.add(votePanel, "vote");
+
+        setSize(900, 600);
+        setLocationRelativeTo(null);
+    }
+
+    public void showLogin() { layout.show(container, "login"); }
+    public void showHackathon() { layout.show(container, "hackathon"); }
+    public void showTeam() { layout.show(container, "team"); }
+    public void showProgress() { layout.show(container, "progress"); }
+    public void showVote() { layout.show(container, "vote"); }
+
+    public LoginPanel getLoginPanel() { return loginPanel; }
+    public HackathonPanel getHackathonPanel() { return hackathonPanel; }
+    public TeamPanel getTeamPanel() { return teamPanel; }
+    public ProgressPanel getProgressPanel() { return progressPanel; }
+    public VotePanel getVotePanel() { return votePanel; }
+}

--- a/src/main/java/gui/ProgressPanel.java
+++ b/src/main/java/gui/ProgressPanel.java
@@ -1,0 +1,43 @@
+package gui;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionListener;
+
+/**
+ * Panel for uploading and reviewing project progress documents.
+ */
+public class ProgressPanel extends JPanel {
+    private final JTextArea descriptionArea = new JTextArea(5, 30);
+    private final JTextArea reviewArea = new JTextArea(10, 30);
+    private final JButton uploadButton = new JButton("Upload");
+    private final JButton reviewButton = new JButton("Review");
+
+    public ProgressPanel() {
+        setLayout(new BorderLayout(5,5));
+
+        JPanel top = new JPanel(new BorderLayout());
+        top.add(new JLabel("Description:"), BorderLayout.NORTH);
+        top.add(new JScrollPane(descriptionArea), BorderLayout.CENTER);
+        add(top, BorderLayout.NORTH);
+
+        JPanel buttons = new JPanel();
+        buttons.add(uploadButton);
+        buttons.add(reviewButton);
+        add(buttons, BorderLayout.CENTER);
+
+        reviewArea.setEditable(false);
+        add(new JScrollPane(reviewArea), BorderLayout.SOUTH);
+    }
+
+    public void addUploadListener(ActionListener listener) {
+        uploadButton.addActionListener(listener);
+    }
+
+    public void addReviewListener(ActionListener listener) {
+        reviewButton.addActionListener(listener);
+    }
+
+    public JTextArea getDescriptionArea() { return descriptionArea; }
+    public JTextArea getReviewArea() { return reviewArea; }
+}

--- a/src/main/java/gui/TeamPanel.java
+++ b/src/main/java/gui/TeamPanel.java
@@ -1,0 +1,44 @@
+package gui;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionListener;
+
+/**
+ * Panel dealing with team creation and invitations.
+ */
+public class TeamPanel extends JPanel {
+    private final JTextField teamNameField = new JTextField(20);
+    private final JTextField inviteEmailField = new JTextField(20);
+    private final JButton createTeamButton = new JButton("Create Team");
+    private final JButton inviteButton = new JButton("Invite");
+
+    public TeamPanel() {
+        setLayout(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(4,4,4,4);
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+
+        gbc.gridx = 0; gbc.gridy = 0; add(new JLabel("Team name:"), gbc);
+        gbc.gridx = 1; add(teamNameField, gbc);
+        gbc.gridx = 0; gbc.gridy = 1; add(new JLabel("Invite email:"), gbc);
+        gbc.gridx = 1; add(inviteEmailField, gbc);
+
+        gbc.gridx = 0; gbc.gridy = 2; gbc.gridwidth = 2;
+        JPanel buttons = new JPanel();
+        buttons.add(createTeamButton);
+        buttons.add(inviteButton);
+        add(buttons, gbc);
+    }
+
+    public void addCreateTeamListener(ActionListener listener) {
+        createTeamButton.addActionListener(listener);
+    }
+
+    public void addInviteListener(ActionListener listener) {
+        inviteButton.addActionListener(listener);
+    }
+
+    public JTextField getTeamNameField() { return teamNameField; }
+    public JTextField getInviteEmailField() { return inviteEmailField; }
+}

--- a/src/main/java/gui/VotePanel.java
+++ b/src/main/java/gui/VotePanel.java
@@ -1,0 +1,52 @@
+package gui;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionListener;
+
+/**
+ * Panel allowing judges to vote teams and display the ranking.
+ */
+public class VotePanel extends JPanel {
+    private final JTextField teamIdField = new JTextField(5);
+    private final JTextField valueField = new JTextField(3);
+    private final JTextArea rankingArea = new JTextArea(10, 30);
+    private final JButton voteButton = new JButton("Vote");
+    private final JButton rankingButton = new JButton("Ranking");
+
+    public VotePanel() {
+        setLayout(new BorderLayout(5,5));
+
+        JPanel form = new JPanel(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(4,4,4,4);
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+
+        gbc.gridx = 0; gbc.gridy = 0; form.add(new JLabel("Team ID:"), gbc);
+        gbc.gridx = 1; form.add(teamIdField, gbc);
+        gbc.gridx = 0; gbc.gridy = 1; form.add(new JLabel("Vote (0-10):"), gbc);
+        gbc.gridx = 1; form.add(valueField, gbc);
+        gbc.gridx = 0; gbc.gridy = 2; gbc.gridwidth = 2;
+        JPanel buttons = new JPanel();
+        buttons.add(voteButton);
+        buttons.add(rankingButton);
+        form.add(buttons, gbc);
+
+        add(form, BorderLayout.NORTH);
+
+        rankingArea.setEditable(false);
+        add(new JScrollPane(rankingArea), BorderLayout.CENTER);
+    }
+
+    public void addVoteListener(ActionListener listener) {
+        voteButton.addActionListener(listener);
+    }
+
+    public void addShowRankingListener(ActionListener listener) {
+        rankingButton.addActionListener(listener);
+    }
+
+    public JTextField getTeamIdField() { return teamIdField; }
+    public JTextField getValueField() { return valueField; }
+    public JTextArea getRankingArea() { return rankingArea; }
+}


### PR DESCRIPTION
## Summary
- build MainFrame with CardLayout to switch between login, hackathon, team, progress and voting panels
- add Swing panels (LoginPanel, HackathonPanel, TeamPanel, ProgressPanel, VotePanel) exposing listener hooks and field getters for actions like hackathon CRUD, registrations, invitations, progress review and voting

## Testing
- `mvn -q -Dmaven.test.skip=false test` *(fails: PluginResolutionException: maven-resources-plugin:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_6891506ccc5c83299ec542f70b9486f6