### PR TITLE
Add SonarQube analysis step to Maven workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,5 +14,10 @@ jobs:
           java-version: 17
       - name: Build
         run: mvn -B verify
+      - name: SonarQube Scan
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        run: mvn -B sonar:sonar
       - name: Javadoc
         run: mvn -B javadoc:javadoc


### PR DESCRIPTION
## Summary
- add SonarQube scan to Maven workflow

## Testing
- `mvn -B verify` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891506f01a8832989fb54ff1b5d8cf8