### PR TITLE
Add DAO and controller tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
       <maven.compiler.source>17</maven.compiler.source>
       <maven.compiler.target>17</maven.compiler.target>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <maven.test.skip>true</maven.test.skip>
+      <maven.test.skip>false</maven.test.skip>
       <maven.resources.skip>true</maven.resources.skip>
     </properties>
   <dependencies>
@@ -20,6 +20,24 @@
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
       <version>42.7.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>2.2.224</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.6.0</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/java/controller/Controller.java
+++ b/src/main/java/controller/Controller.java
@@ -3,9 +3,17 @@ package controller;
 import dao.HackathonDAO;
 import dao.TeamDAO;
 import dao.UtenteDAO;
+import dao.VoteDAO;
 import model.Hackathon;
 import model.Team;
 import model.Utente;
+import model.Invitation;
+import model.Vote;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Coordina i casi d'uso principali dell'applicazione.
@@ -14,11 +22,15 @@ public class Controller {
     private final UtenteDAO utenteDAO;
     private final HackathonDAO hackathonDAO;
     private final TeamDAO teamDAO;
+    private final VoteDAO voteDAO;
+    private final List<Invitation> invitations = new ArrayList<>();
+    private final List<Vote> votes = new ArrayList<>();
 
-    public Controller(UtenteDAO utenteDAO, HackathonDAO hackathonDAO, TeamDAO teamDAO) {
+    public Controller(UtenteDAO utenteDAO, HackathonDAO hackathonDAO, TeamDAO teamDAO, VoteDAO voteDAO) {
         this.utenteDAO = utenteDAO;
         this.hackathonDAO = hackathonDAO;
         this.teamDAO = teamDAO;
+        this.voteDAO = voteDAO;
     }
 
     /** Crea un nuovo hackathon. */
@@ -50,5 +62,39 @@ public class Controller {
             teamDAO.save(team);
         }
         return ok;
+    }
+
+    /** Crea un invito per un partecipante. */
+    public Invitation invite(Hackathon h, Utente u) {
+        Invitation inv = new Invitation(h, u);
+        invitations.add(inv);
+        return inv;
+    }
+
+    /** Risponde a un invito. */
+    public void respondInvitation(Invitation inv, boolean accept) {
+        if (accept) inv.accept(); else inv.reject();
+    }
+
+    /** Salva un voto e aggiorna le statistiche. */
+    public void addVote(Vote v) {
+        votes.add(v);
+        voteDAO.save(v);
+    }
+
+    /** Restituisce la classifica dei team in base alla media dei voti. */
+    public List<Team> getRanking() {
+        Map<Team, List<Vote>> map = new HashMap<>();
+        for (Vote v : votes) {
+            map.computeIfAbsent(v.getTeam(), k -> new ArrayList<>()).add(v);
+        }
+        return map.entrySet().stream()
+                .sorted((e1, e2) -> Double.compare(avg(e2.getValue()), avg(e1.getValue())))
+                .map(Map.Entry::getKey)
+                .toList();
+    }
+
+    private double avg(List<Vote> vs) {
+        return vs.stream().mapToInt(Vote::getValore).average().orElse(0);
     }
 }

--- a/src/main/java/implementazionePostgresDAO/PostgresHackathonDAO.java
+++ b/src/main/java/implementazionePostgresDAO/PostgresHackathonDAO.java
@@ -1,0 +1,60 @@
+package implementazionePostgresDAO;
+
+import dao.HackathonDAO;
+import database.DatabaseConfig;
+import model.Hackathon;
+import model.Utente;
+
+import java.sql.*;
+import java.time.LocalDate;
+import java.util.Optional;
+
+/** Implementazione PostgreSQL di {@link HackathonDAO}. */
+public class PostgresHackathonDAO implements HackathonDAO {
+    @Override
+    public void save(Hackathon h) {
+        String sql = "INSERT INTO hackathons(id,titolo,inizio,fine,chiusura_iscrizioni,max_partecipanti,max_team,organizzatore_id) VALUES(?,?,?,?,?,?,?,?)";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, h.getId());
+            ps.setString(2, h.getTitolo());
+            ps.setDate(3, Date.valueOf(h.getInizio()));
+            ps.setDate(4, Date.valueOf(h.getFine()));
+            ps.setDate(5, Date.valueOf(h.getChiusuraIscrizioni()));
+            ps.setInt(6, h.getMaxPartecipanti());
+            ps.setInt(7, h.getMaxTeam());
+            ps.setInt(8, h.getOrganizzatore().getId());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Optional<Hackathon> findById(int id) {
+        String sql = "SELECT id,titolo,inizio,fine,chiusura_iscrizioni,max_partecipanti,max_team,organizzatore_id FROM hackathons WHERE id=?";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    Utente org = new Utente(rs.getInt("organizzatore_id"), "", "", Utente.Ruolo.ORGANIZER);
+                    Hackathon h = new Hackathon(
+                            rs.getInt("id"),
+                            rs.getString("titolo"),
+                            rs.getDate("inizio").toLocalDate(),
+                            rs.getDate("fine").toLocalDate(),
+                            rs.getDate("chiusura_iscrizioni").toLocalDate(),
+                            rs.getInt("max_partecipanti"),
+                            rs.getInt("max_team"),
+                            org
+                    );
+                    return Optional.of(h);
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/implementazionePostgresDAO/PostgresProgressDAO.java
+++ b/src/main/java/implementazionePostgresDAO/PostgresProgressDAO.java
@@ -1,0 +1,54 @@
+package implementazionePostgresDAO;
+
+import dao.ProgressDAO;
+import database.DatabaseConfig;
+import model.Progress;
+import model.Team;
+import model.Utente;
+
+import java.sql.*;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+/** Implementazione PostgreSQL di {@link ProgressDAO}. */
+public class PostgresProgressDAO implements ProgressDAO {
+    @Override
+    public void save(Progress p) {
+        String sql = "INSERT INTO progressi(id,team_id,descrizione,timestamp) VALUES(?,?,?,?)";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, p.getId());
+            ps.setInt(2, p.getTeam().getId());
+            ps.setString(3, p.getDescrizione());
+            ps.setTimestamp(4, Timestamp.valueOf(p.getTimestamp()));
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Optional<Progress> findById(int id) {
+        String sql = "SELECT id,team_id,descrizione,timestamp FROM progressi WHERE id=?";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    Team team = new Team(rs.getInt("team_id"), "", 0,
+                            new Utente(0, "", "", Utente.Ruolo.PARTICIPANT));
+                    Progress p = new Progress(
+                            rs.getInt("id"),
+                            team,
+                            rs.getString("descrizione"),
+                            rs.getTimestamp("timestamp").toLocalDateTime()
+                    );
+                    return Optional.of(p);
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/implementazionePostgresDAO/PostgresTeamDAO.java
+++ b/src/main/java/implementazionePostgresDAO/PostgresTeamDAO.java
@@ -1,0 +1,71 @@
+package implementazionePostgresDAO;
+
+import dao.TeamDAO;
+import database.DatabaseConfig;
+import model.Team;
+import model.Utente;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/** Implementazione PostgreSQL di {@link TeamDAO}. */
+public class PostgresTeamDAO implements TeamDAO {
+    @Override
+    public void save(Team team) {
+        try (Connection c = DatabaseConfig.getConnection()) {
+            try (PreparedStatement ps = c.prepareStatement("INSERT INTO teams(id,nome,max_size) VALUES(?,?,?)")) {
+                ps.setInt(1, team.getId());
+                ps.setString(2, team.getNome());
+                ps.setInt(3, team.getMaxSize());
+                ps.executeUpdate();
+            }
+            try (PreparedStatement ps = c.prepareStatement("INSERT INTO team_members(team_id,utente_id) VALUES(?,?)")) {
+                for (Utente u : team.getMembri()) {
+                    ps.setInt(1, team.getId());
+                    ps.setInt(2, u.getId());
+                    ps.addBatch();
+                }
+                ps.executeBatch();
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Optional<Team> findById(int id) {
+        String teamSql = "SELECT id,nome,max_size FROM teams WHERE id=?";
+        String memSql = "SELECT utente_id FROM team_members WHERE team_id=?";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement tps = c.prepareStatement(teamSql);
+             PreparedStatement mps = c.prepareStatement(memSql)) {
+            tps.setInt(1, id);
+            try (ResultSet trs = tps.executeQuery()) {
+                if (!trs.next()) return Optional.empty();
+                String nome = trs.getString("nome");
+                int max = trs.getInt("max_size");
+                mps.setInt(1, id);
+                try (ResultSet mrs = mps.executeQuery()) {
+                    List<Integer> ids = new ArrayList<>();
+                    while (mrs.next()) ids.add(mrs.getInt("utente_id"));
+                    Utente creator;
+                    if (ids.isEmpty()) {
+                        creator = new Utente(0, "", "", Utente.Ruolo.PARTICIPANT);
+                    } else {
+                        creator = new Utente(ids.get(0), "", "", Utente.Ruolo.PARTICIPANT);
+                    }
+                    Team team = new Team(id, nome, max, creator);
+                    for (int i = 1; i < ids.size(); i++) {
+                        team.aggiungiMembro(new Utente(ids.get(i), "", "", Utente.Ruolo.PARTICIPANT));
+                    }
+                    return Optional.of(team);
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/implementazionePostgresDAO/PostgresVoteDAO.java
+++ b/src/main/java/implementazionePostgresDAO/PostgresVoteDAO.java
@@ -1,0 +1,49 @@
+package implementazionePostgresDAO;
+
+import dao.VoteDAO;
+import database.DatabaseConfig;
+import model.Team;
+import model.Utente;
+import model.Vote;
+
+import java.sql.*;
+import java.util.Optional;
+
+/** Implementazione PostgreSQL di {@link VoteDAO}. */
+public class PostgresVoteDAO implements VoteDAO {
+    @Override
+    public void save(Vote vote) {
+        String sql = "INSERT INTO voti(id,team_id,giudice_id,valore) VALUES(?,?,?,?)";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, vote.getId());
+            ps.setInt(2, vote.getTeam().getId());
+            ps.setInt(3, vote.getGiudice().getId());
+            ps.setInt(4, vote.getValore());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Optional<Vote> findById(int id) {
+        String sql = "SELECT id,team_id,giudice_id,valore FROM voti WHERE id=?";
+        try (Connection c = DatabaseConfig.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    Team team = new Team(rs.getInt("team_id"), "", 0,
+                            new Utente(0, "", "", Utente.Ruolo.PARTICIPANT));
+                    Utente giudice = new Utente(rs.getInt("giudice_id"), "", "", Utente.Ruolo.JUDGE);
+                    Vote v = new Vote(rs.getInt("id"), team, giudice, rs.getInt("valore"));
+                    return Optional.of(v);
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/model/Invitation.java
+++ b/src/main/java/model/Invitation.java
@@ -1,0 +1,20 @@
+package model;
+
+/** Simple invitation for a user to join a hackathon. */
+public class Invitation {
+    private final Hackathon hackathon;
+    private final Utente invitee;
+    private Boolean accepted; // null=pending
+
+    public Invitation(Hackathon hackathon, Utente invitee) {
+        this.hackathon = hackathon;
+        this.invitee = invitee;
+    }
+
+    public Hackathon getHackathon() { return hackathon; }
+    public Utente getInvitee() { return invitee; }
+    public Boolean getAccepted() { return accepted; }
+
+    public void accept() { this.accepted = true; }
+    public void reject() { this.accepted = false; }
+}

--- a/src/test/java/controller/ControllerFeaturesTest.java
+++ b/src/test/java/controller/ControllerFeaturesTest.java
@@ -1,0 +1,87 @@
+package controller;
+
+import dao.HackathonDAO;
+import dao.TeamDAO;
+import dao.UtenteDAO;
+import dao.VoteDAO;
+import model.Hackathon;
+import model.Invitation;
+import model.Team;
+import model.Utente;
+import model.Vote;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Additional tests for {@link Controller}. */
+public class ControllerFeaturesTest {
+    private Controller createController() {
+        UtenteDAO udao = Mockito.mock(UtenteDAO.class);
+        HackathonDAO hdao = Mockito.mock(HackathonDAO.class);
+        TeamDAO tdao = Mockito.mock(TeamDAO.class);
+        VoteDAO vdao = Mockito.mock(VoteDAO.class);
+        return new Controller(udao, hdao, tdao, vdao);
+    }
+
+    @Test
+    void registrationDeadlineEnforced() {
+        UtenteDAO udao = Mockito.mock(UtenteDAO.class);
+        Controller c = new Controller(udao, Mockito.mock(HackathonDAO.class), Mockito.mock(TeamDAO.class), Mockito.mock(VoteDAO.class));
+        Utente org = new Utente(1, "Org", "o@x.com", Utente.Ruolo.ORGANIZER);
+        Hackathon h = new Hackathon(1, "Hack", LocalDate.now(), LocalDate.now().plusDays(1),
+                LocalDate.now().minusDays(1), 10, 2, org);
+        boolean ok = c.registerUser(h, new Utente(2, "Bob", "b@x.com", Utente.Ruolo.PARTICIPANT));
+        assertFalse(ok);
+        Mockito.verify(udao, Mockito.never()).save(Mockito.any());
+    }
+
+    @Test
+    void maxParticipantsPerHackathon() {
+        Utente org = new Utente(1, "Org", "o@x.com", Utente.Ruolo.ORGANIZER);
+        Hackathon h = new Hackathon(1, "Hack", LocalDate.now(), LocalDate.now().plusDays(1),
+                LocalDate.now().plusDays(1), 1, 2, org);
+        UtenteDAO udao = Mockito.mock(UtenteDAO.class);
+        Controller c = new Controller(udao, Mockito.mock(HackathonDAO.class), Mockito.mock(TeamDAO.class), Mockito.mock(VoteDAO.class));
+        assertTrue(c.registerUser(h, new Utente(2, "Bob", "b@x.com", Utente.Ruolo.PARTICIPANT)));
+        assertFalse(c.registerUser(h, new Utente(3, "Carl", "c@x.com", Utente.Ruolo.PARTICIPANT)));
+        Mockito.verify(udao, Mockito.times(1)).save(Mockito.any());
+    }
+
+    @Test
+    void invitationAcceptanceRejection() {
+        Controller c = createController();
+        Utente org = new Utente(1, "Org", "o@x.com", Utente.Ruolo.ORGANIZER);
+        Hackathon h = new Hackathon(1, "Hack", LocalDate.now(), LocalDate.now().plusDays(1),
+                LocalDate.now().plusDays(1), 10, 2, org);
+        Utente invitee = new Utente(2, "Bob", "b@x.com", Utente.Ruolo.PARTICIPANT);
+        Invitation inv = Mockito.spy(c.invite(h, invitee));
+        c.respondInvitation(inv, true);
+        Mockito.verify(inv).accept();
+        Invitation inv2 = Mockito.spy(c.invite(h, invitee));
+        c.respondInvitation(inv2, false);
+        Mockito.verify(inv2).reject();
+    }
+
+    @Test
+    void voteAggregationAndRanking() {
+        UtenteDAO udao = Mockito.mock(UtenteDAO.class);
+        HackathonDAO hdao = Mockito.mock(HackathonDAO.class);
+        TeamDAO tdao = Mockito.mock(TeamDAO.class);
+        VoteDAO vdao = Mockito.mock(VoteDAO.class);
+        Controller c = new Controller(udao, hdao, tdao, vdao);
+        Utente judge = new Utente(10, "J", "j@x.com", Utente.Ruolo.JUDGE);
+        Utente creator = new Utente(1, "C", "c@x.com", Utente.Ruolo.PARTICIPANT);
+        Team t1 = new Team(1, "T1", 3, creator);
+        Team t2 = new Team(2, "T2", 3, creator);
+        c.addVote(new Vote(1, t1, judge, 5));
+        c.addVote(new Vote(2, t1, judge, 7));
+        c.addVote(new Vote(3, t2, judge, 8));
+        Mockito.verify(vdao, Mockito.times(3)).save(Mockito.any());
+        List<Team> ranking = c.getRanking();
+        assertEquals(t2, ranking.get(0));
+    }
+}

--- a/src/test/java/controller/ControllerTest.java
+++ b/src/test/java/controller/ControllerTest.java
@@ -3,6 +3,7 @@ package controller;
 import dao.HackathonDAO;
 import dao.TeamDAO;
 import dao.UtenteDAO;
+import dao.VoteDAO;
 import model.Hackathon;
 import model.Team;
 import model.Utente;
@@ -23,7 +24,8 @@ public class ControllerTest {
         UtenteDAO udao = Mockito.mock(UtenteDAO.class);
         HackathonDAO hdao = Mockito.mock(HackathonDAO.class);
         TeamDAO tdao = Mockito.mock(TeamDAO.class);
-        Controller c = new Controller(udao, hdao, tdao);
+        VoteDAO vdao = Mockito.mock(VoteDAO.class);
+        Controller c = new Controller(udao, hdao, tdao, vdao);
         Team team = c.formTeam(h, "team", creator);
         assertTrue(c.joinTeam(team, new Utente(2, "Bob", "b@b.com", Utente.Ruolo.PARTICIPANT)));
         assertFalse(c.joinTeam(team, new Utente(3, "Carl", "c@b.com", Utente.Ruolo.PARTICIPANT)));

--- a/src/test/java/dao/PostgresHackathonDAOTest.java
+++ b/src/test/java/dao/PostgresHackathonDAOTest.java
@@ -1,0 +1,41 @@
+package dao;
+
+import implementazionePostgresDAO.PostgresHackathonDAO;
+import implementazionePostgresDAO.PostgresUtenteDAO;
+import model.Hackathon;
+import model.Utente;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Test per {@link PostgresHackathonDAO}. */
+public class PostgresHackathonDAOTest {
+    private PostgresHackathonDAO dao;
+
+    @BeforeEach
+    void setup() throws Exception {
+        System.setProperty("db.url", "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1");
+        System.setProperty("db.user", "sa");
+        System.setProperty("db.password", "");
+        dao = new PostgresHackathonDAO();
+        try (Connection c = database.DatabaseConfig.getConnection();
+             Statement st = c.createStatement()) {
+            st.executeUpdate("CREATE TABLE utenti(id INT PRIMARY KEY, nome VARCHAR(100), email VARCHAR(100), ruolo VARCHAR(20))");
+            st.executeUpdate("CREATE TABLE hackathons(id INT PRIMARY KEY, titolo VARCHAR(100), inizio DATE, fine DATE, chiusura_iscrizioni DATE, max_partecipanti INT, max_team INT, organizzatore_id INT)");
+        }
+    }
+
+    @Test
+    void saveAndFind() {
+        Utente org = new Utente(1, "Org", "o@x.com", Utente.Ruolo.ORGANIZER);
+        new PostgresUtenteDAO().save(org);
+        Hackathon h = new Hackathon(1, "Hack", LocalDate.now(), LocalDate.now().plusDays(1), LocalDate.now().plusDays(1), 10, 2, org);
+        dao.save(h);
+        assertEquals("Hack", dao.findById(1).orElseThrow().getTitolo());
+    }
+}

--- a/src/test/java/dao/PostgresProgressDAOTest.java
+++ b/src/test/java/dao/PostgresProgressDAOTest.java
@@ -1,0 +1,39 @@
+package dao;
+
+import implementazionePostgresDAO.PostgresProgressDAO;
+import model.Progress;
+import model.Team;
+import model.Utente;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Test per {@link PostgresProgressDAO}. */
+public class PostgresProgressDAOTest {
+    private PostgresProgressDAO dao;
+
+    @BeforeEach
+    void setup() throws Exception {
+        System.setProperty("db.url", "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1");
+        System.setProperty("db.user", "sa");
+        System.setProperty("db.password", "");
+        dao = new PostgresProgressDAO();
+        try (Connection c = database.DatabaseConfig.getConnection();
+             Statement st = c.createStatement()) {
+            st.executeUpdate("CREATE TABLE progressi(id INT PRIMARY KEY, team_id INT, descrizione VARCHAR(255), timestamp TIMESTAMP)");
+        }
+    }
+
+    @Test
+    void saveAndFind() {
+        Team team = new Team(1, "T", 3, new Utente(1, "A", "a@x.com", Utente.Ruolo.PARTICIPANT));
+        Progress p = new Progress(1, team, "descr", LocalDateTime.now());
+        dao.save(p);
+        assertEquals("descr", dao.findById(1).orElseThrow().getDescrizione());
+    }
+}

--- a/src/test/java/dao/PostgresTeamDAOTest.java
+++ b/src/test/java/dao/PostgresTeamDAOTest.java
@@ -1,0 +1,45 @@
+package dao;
+
+import implementazionePostgresDAO.PostgresTeamDAO;
+import implementazionePostgresDAO.PostgresUtenteDAO;
+import model.Team;
+import model.Utente;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Test per {@link PostgresTeamDAO}. */
+public class PostgresTeamDAOTest {
+    private PostgresTeamDAO dao;
+
+    @BeforeEach
+    void setup() throws Exception {
+        System.setProperty("db.url", "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1");
+        System.setProperty("db.user", "sa");
+        System.setProperty("db.password", "");
+        dao = new PostgresTeamDAO();
+        try (Connection c = database.DatabaseConfig.getConnection();
+             Statement st = c.createStatement()) {
+            st.executeUpdate("CREATE TABLE utenti(id INT PRIMARY KEY, nome VARCHAR(100), email VARCHAR(100), ruolo VARCHAR(20))");
+            st.executeUpdate("CREATE TABLE teams(id INT PRIMARY KEY, nome VARCHAR(100), max_size INT)");
+            st.executeUpdate("CREATE TABLE team_members(team_id INT, utente_id INT)");
+        }
+    }
+
+    @Test
+    void saveAndFind() {
+        Utente u1 = new Utente(1, "A", "a@x.com", Utente.Ruolo.PARTICIPANT);
+        Utente u2 = new Utente(2, "B", "b@x.com", Utente.Ruolo.PARTICIPANT);
+        PostgresUtenteDAO udao = new PostgresUtenteDAO();
+        udao.save(u1);
+        udao.save(u2);
+        Team t = new Team(1, "Team", 3, u1);
+        t.aggiungiMembro(u2);
+        dao.save(t);
+        assertEquals(2, dao.findById(1).orElseThrow().getMembri().size());
+    }
+}

--- a/src/test/java/dao/PostgresVoteDAOTest.java
+++ b/src/test/java/dao/PostgresVoteDAOTest.java
@@ -1,0 +1,39 @@
+package dao;
+
+import implementazionePostgresDAO.PostgresVoteDAO;
+import model.Team;
+import model.Utente;
+import model.Vote;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Test per {@link PostgresVoteDAO}. */
+public class PostgresVoteDAOTest {
+    private PostgresVoteDAO dao;
+
+    @BeforeEach
+    void setup() throws Exception {
+        System.setProperty("db.url", "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1");
+        System.setProperty("db.user", "sa");
+        System.setProperty("db.password", "");
+        dao = new PostgresVoteDAO();
+        try (Connection c = database.DatabaseConfig.getConnection();
+             Statement st = c.createStatement()) {
+            st.executeUpdate("CREATE TABLE voti(id INT PRIMARY KEY, team_id INT, giudice_id INT, valore INT)");
+        }
+    }
+
+    @Test
+    void saveAndFind() {
+        Team team = new Team(1, "T", 3, new Utente(1, "A", "a@x.com", Utente.Ruolo.PARTICIPANT));
+        Utente judge = new Utente(2, "J", "j@x.com", Utente.Ruolo.JUDGE);
+        Vote v = new Vote(1, team, judge, 8);
+        dao.save(v);
+        assertEquals(8, dao.findById(1).orElseThrow().getValore());
+    }
+}


### PR DESCRIPTION
## Summary
- Add invitation and vote handling to controller
- Introduce in-memory DAO tests using H2
- Cover controller constraints and flows with Mockito

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891506f65388329bc8157cad1e76972